### PR TITLE
Escape the html from the usage field in the documentation page.

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "death": "^1.1.0",
     "discord.js": "github:hydrabolt/discord.js",
     "ejs": "^2.5.7",
+    "escape-html": "^1.0.3",
     "express": "^4.16.2",
     "express-session": "^1.15.6",
     "glob": "^7.1.2",

--- a/src/web/web.js
+++ b/src/web/web.js
@@ -26,7 +26,7 @@ module.exports = async cookieblob => {
     });
 
     app.get("/docs", (req, res) => {
-        res.render("docs", {title: "Docs", commands: Array.from(cookieblob.commands.values()), Util});
+        res.render("docs", {title: "Docs", commands: Array.from(cookieblob.commands.values()), Util, escapeHTML: require("escape-html")});
     });
     app.get("/stats", (req, res) => {
         res.render("stats", {title: "Stats"});

--- a/views/docs.ejs
+++ b/views/docs.ejs
@@ -17,7 +17,7 @@
                             </tr>
                         </thead>
                         <tbody>
-                            <%- commands.map(cmd => `<tr><th>${cmd.formatCommand()}</th> <th>${cmd.description}</th><th>${cmd.formatPermissionLevel()}</th><th>${cmd.guildOnly ? "Yes" : "No"}</th></tr>`).join("") %>
+                            <%- commands.map(cmd => `<tr><th>${escapeHTML(cmd.formatCommand())}</th> <th>${cmd.description}</th><th>${cmd.formatPermissionLevel()}</th><th>${cmd.guildOnly ? "Yes" : "No"}</th></tr>`).join("") %>
                         </tbody>
                     </table>
                 </div>


### PR DESCRIPTION
It wasn't escaping the html so it didn't show the full usage ):